### PR TITLE
Fix invalid layout constraint

### DIFF
--- a/app/src/main/res/layout/fragment_blocked_url_settings.xml
+++ b/app/src/main/res/layout/fragment_blocked_url_settings.xml
@@ -184,7 +184,7 @@
             android:background="@android:color/transparent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/text1" />
+            app:layout_constraintTop_toBottomOf="@id/text3" />
     </android.support.constraint.ConstraintLayout>
 
 


### PR DESCRIPTION
Commit f5a9a69 introduced an error that caused Android Studio to complain about an invalid constraint: https://github.com/LayoutXML/SABS/blob/f5a9a69176e56e64e1e7174a9262e3a85b474251/app/src/main/res/layout/fragment_blocked_url_settings.xml#L187