### PR TITLE
Fixed broken link for standard-package

### DIFF
--- a/app/src/main/java/com/layoutxml/sabs/MainActivity.java
+++ b/app/src/main/java/com/layoutxml/sabs/MainActivity.java
@@ -60,7 +60,7 @@ import static com.layoutxml.sabs.Global.BlockedUniqueUrls;
 
 
 public class MainActivity extends AppCompatActivity {
-    public static final String PACKAGE = "https://raw.githubusercontent.com/LayoutXML/SABS-Package/master/package.txt";
+    public static final String PACKAGE = "https://raw.githubusercontent.com/LayoutXML/SABS/master/standard-package.txt";
     public static final String SABS_MMOTTI_PACKAGE = "https://raw.githubusercontent.com/mmotti/mmotti-host-file/master/wildcard_standard_hosts.txt";
     private static final String TAG = MainActivity.class.getCanonicalName();
     private static final String BACK_STACK_TAB_TAG = "tab_fragment";


### PR DESCRIPTION
The given link for standard-package is currently broken, replaced it withe the standard-package.txt file in the root of the repository.